### PR TITLE
fix: update footer GitHub link to point to Rav repository

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -18,7 +18,7 @@ interface FooterLink {
 const footerLinks: FooterLink[] = [
   {
     name: 'Github',
-    url: 'https://github.com/yikZero',
+    url: 'https://github.com/yikZero/Rav',
     icon: Github,
   },
   {


### PR DESCRIPTION
This PR addresses issue #31 by replacing the Footer bottom GitHub link with the repository link.

## Changes
- Updated GitHub link in `components/footer.tsx` from `https://github.com/yikZero` to `https://github.com/yikZero/Rav`
- This provides direct access to the blog's open source repository from the footer

Closes #31

Generated with [Claude Code](https://claude.ai/code)